### PR TITLE
デプロイ設定修正

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -5,6 +5,7 @@ const config: GatsbyConfig = {
     title: `tc-website`,
     siteUrl: `https://tc-online.tik-choco.com`
   },
+  pathPrefix: `/tc-website`,
   // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
   // If you use VSCode you can also use the GraphQL plugin
   // Learn more at: https://gatsby.dev/graphql-typegen

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "develop": "gatsby develop",
         "start": "gatsby develop",
-        "build": "cross-env PUBLIC_URL=/tik-choco/tc-website gatsby build",
+        "build": "cross-env PUBLIC_URL=/tik-choco/tc-website gatsby build --prefix-paths",
         "serve": "gatsby serve",
         "clean": "gatsby clean",
         "typecheck": "tsc --noEmit",


### PR DESCRIPTION
JSエラーの原因がわかりました。現在サイトのurlがhttps://tik-choco.github.io/tc-website/ となっているが、ビルドされたファイルのsrcがhttps://tik-choco.github.io/ となっています。pathPrefixをつければ解消できました。